### PR TITLE
Add FastAPI backend for polygon data

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,22 @@ UrbanVista là một ứng dụng web giúp quản lý và trực quan hóa dữ
    - `npm run start`
   
 6. Truy cập vào [`đường dẫn`](http://localhost:3000/)
+
+## Backend API
+A simple FastAPI service is provided in `backend/` to read polygon data from a PostgreSQL database.
+
+### Setup
+1. Install requirements (FastAPI and SQLAlchemy).
+2. Set `DATABASE_URL` environment variable to your PostgreSQL connection string.
+3. Run the service:
+   ```bash
+   uvicorn backend.app:app --reload
+   ```
+
+### Loading data
+To import polygons from a JSON file, call the helper:
+```python
+from backend.app import load_from_json, SessionLocal
+with SessionLocal() as session:
+    load_from_json("path/to/polygons.json", session)
+```

--- a/backend/app.py
+++ b/backend/app.py
@@ -1,0 +1,47 @@
+from fastapi import FastAPI, Depends, HTTPException
+from sqlalchemy.orm import Session
+import json
+import os
+
+from .models import Polygon3D, SessionLocal, init_engine
+from .schemas import Polygon3DRead, Polygon3DCreate
+
+DB_URL = os.environ.get("DATABASE_URL", "postgresql://postgres:password@localhost/db")
+init_engine(DB_URL)
+
+app = FastAPI()
+
+# Dependency
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+@app.post("/polygons", response_model=Polygon3DRead)
+def create_polygon(polygon: Polygon3DCreate, db: Session = Depends(get_db)):
+    db_polygon = Polygon3D(**polygon.dict())
+    db.add(db_polygon)
+    db.commit()
+    db.refresh(db_polygon)
+    return db_polygon
+
+@app.get("/polygons", response_model=list[Polygon3DRead])
+def read_polygons(db: Session = Depends(get_db)):
+    return db.query(Polygon3D).all()
+
+# Utility to load polygons from a JSON file
+
+def load_from_json(path: str, db: Session):
+    with open(path) as f:
+        data = json.load(f)
+    for item in data.get("polygons", []):
+        poly = Polygon3D(name=item.get("name"), color=','.join(map(str, item.get("symbol", {}).get("color", []))), rings=item.get("rings"))
+        db.add(poly)
+    db.commit()
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,0 +1,22 @@
+from sqlalchemy import create_engine, Column, Integer, String, Float
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker
+from sqlalchemy.dialects.postgresql import JSONB
+from sqlalchemy.types import UserDefinedType
+
+Base = declarative_base()
+
+class Polygon3D(Base):
+    __tablename__ = "polygon"
+    poly_id = Column(Integer, primary_key=True)
+    name = Column(String)
+    color = Column(String)
+    rings = Column(JSONB)
+
+# Database utility
+SessionLocal = sessionmaker()
+
+def init_engine(db_url: str):
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+    SessionLocal.configure(bind=engine)
+    return engine

--- a/backend/schemas.py
+++ b/backend/schemas.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+from typing import List
+
+class Polygon3DCreate(BaseModel):
+    name: str
+    color: str
+    rings: List[List[float]]
+
+class Polygon3DRead(Polygon3DCreate):
+    poly_id: int
+    class Config:
+        orm_mode = True


### PR DESCRIPTION
## Summary
- create backend with FastAPI and SQLAlchemy models
- expose `/polygons` endpoint for reading/writing polygon data
- add helper to load JSON polygon files
- document backend setup in README

## Testing
- `python3 -m py_compile backend/models.py backend/app.py backend/schemas.py`

------
https://chatgpt.com/codex/tasks/task_e_684fd3cbd5848326872dda32ddf6b37a